### PR TITLE
Owners endpoint and resource rename to match Pivotal Tracker API

### DIFF
--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -88,13 +88,13 @@ type Task struct {
 }
 
 type Person struct {
-	Id                         int        `json:"id"`
-	Name                       string     `json:"name"`
-	Initials                   string     `json:"initials"`
-	Username                   string     `json:"username"`
-	TimeZone                   *TimeZone  `json:"time_zone"`
-	Email                      string     `json:"email"`
-	Kind					   string     `json:"kind"`
+	Id                         int        `json:"id,omitempty"`
+	Name                       string     `json:"name,omitempty"`
+	Initials                   string     `json:"initials,omitempty"`
+	Username                   string     `json:"username,omitempty"`
+	TimeZone                   *TimeZone  `json:"time_zone,omitempty"`
+	Email                      string     `json:"email,omitempty"`
+	Kind                       string     `json:"kind,omitempty"`
 }
 
 type StoryService struct {


### PR DESCRIPTION
I added the /projects/{project_id}/stories/{story_id}/owners endpoint so I could get the owner names of stories.

I also renamed Me to Person since that appears to be the actual name of the resource used by Pivotal Labs (also a bunch of Mes didn't make sense for Owners).
