### PR TITLE
Added support for Account Memberships and Iteration endpoints

### DIFF
--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -42,6 +42,9 @@ type Client struct {
 
 	// Story service
 	Stories *StoryService
+
+	// Membership service
+	Memberships *MembershipService
 }
 
 func NewClient(apiToken string) *Client {
@@ -55,6 +58,7 @@ func NewClient(apiToken string) *Client {
 	client.Me = newMeService(client)
 	client.Projects = newProjectService(client)
 	client.Stories = newStoryService(client)
+	client.Memberships = newMembershipService(client)
 	return client
 }
 

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -45,6 +45,9 @@ type Client struct {
 
 	// Membership service
 	Memberships *MembershipService
+
+	// Iteration service
+	Iterations *IterationService
 }
 
 func NewClient(apiToken string) *Client {
@@ -59,6 +62,7 @@ func NewClient(apiToken string) *Client {
 	client.Projects = newProjectService(client)
 	client.Stories = newStoryService(client)
 	client.Memberships = newMembershipService(client)
+	client.Iterations = newIterationService(client)
 	return client
 }
 

--- a/v5/pivotal/iterations.go
+++ b/v5/pivotal/iterations.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2014 Salsita Software
+// Copyright (C) 2015 Scott Devoid
+// Use of this source code is governed by the MIT License.
+// The license can be found in the LICENSE file.
+package pivotal
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Iteration struct {
+	Number          int        `json:"number,omitempty"`
+	ProjectId       int        `json:"project_id,omitempty"`
+	Length          int        `json:"length,omitempty"`
+	TeamStrength    float64    `json:"team_strength,omitempty"`
+	StoryIds        []int      `json:"story_ids,omitempty"`
+	Stories         []*Story   `json:"stories,omitempty"`
+	Start           *time.Time `json:"start,omitempty"`
+	Finish          *time.Time `json:"finish,omitempty"`
+	Velocity        float64    `json:"velocity,omitempty"`
+	Points          int        `json:"points,omitempty"`
+	AcceptedPoints  int        `json:"accepted_points,omitempty"`
+	EffectivePoints float64    `json:"effective_points,omitempty"`
+	Kind            string     `json:"kind,omitempty"`
+}
+
+type IterationService struct {
+	client *Client
+}
+
+func newIterationService(client *Client) *IterationService {
+	return &IterationService{client}
+}
+
+// Return an iteration from the project.
+func (service *IterationService) Get(projectId int, iterationNumber int) (*Iteration, *http.Response, error) {
+	u := fmt.Sprintf("projects/%v/iterations/%v", projectId, iterationNumber)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var iteration Iteration
+	resp, err := service.client.Do(req, &iteration)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &iteration, resp, err
+}

--- a/v5/pivotal/memberships.go
+++ b/v5/pivotal/memberships.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2014 Salsita Software
+// Copyright (C) 2015 Scott Devoid
+// Use of this source code is governed by the MIT License.
+// The license can be found in the LICENSE file.
+package pivotal
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type ProjectMembership struct {
+	Person         Person
+	ID             int        `json:"id,omitempty"`
+	Kind           string     `json:"kind,omitempty"`
+	AccountID      int        `json:"account_id,omitempty"`
+	Owner          bool       `json:"owner,omitempty"`
+	Admin          bool       `json:"admin,omitempty"`
+	ProjectCreator bool       `json:"project_creator,omitempty"`
+	Timekeeper     bool       `json:"timekeeper,omitempty"`
+	TimeEnterer    bool       `json:"time_enterer,omitempty"`
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+}
+
+type MembershipService struct {
+	client *Client
+}
+
+func newMembershipService(client *Client) *MembershipService {
+	return &MembershipService{client}
+}
+
+// List all of the memberships in an account.
+func (service *MembershipService) List(projectId int) ([]*ProjectMembership, *http.Response, error) {
+	u := fmt.Sprintf("projects/%v/memberships", projectId)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var projectMemberships []*ProjectMembership
+	resp, err := service.client.Do(req, &projectMemberships)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return projectMemberships, resp, err
+}


### PR DESCRIPTION
Hi,

I had filed an issue to add support for Account Memberships endpoint [here](https://github.com/salsita/go-pivotaltracker/issues/13), but I wanted the Iterations endpoint as well, so I started developing both of them.
In this PR, I have added the support for the Account Memberships and Iterations endpoint. Though not all the API methods are covered, I have developed the following API methods only:
1. Account Memberships - [List all of the memberships in an account.](https://www.pivotaltracker.com/help/api/rest/v5#accounts_account_id_memberships_get)
2. Iterations - [Return an iteration from the project.](https://www.pivotaltracker.com/help/api/rest/v5#projects_project_id_iteration_get)

Please look into this PR and let me know if I am missing something in the current development.

Thanks!!!