### PR TITLE
API for the Aggregator Endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,2 @@
+module github.com/oschwald/go-pivotaltracker
+

--- a/go.mod
+++ b/go.mod
@@ -1,2 +1,3 @@
 module github.com/oschwald/go-pivotaltracker
 
+go 1.20

--- a/v5/pivotal/account.go
+++ b/v5/pivotal/account.go
@@ -1,0 +1,41 @@
+package pivotal
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type Account struct {
+	CreatedAt *time.Time `json:"created_at"`
+	ID        int        `json:"id"`
+	Kind      string     `json:"kind"`
+	Name      string     `json:"name"`
+	Plan      string     `json:"plan"`
+	Status    string     `json:"status"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+type AccountsService struct {
+	client *Client
+}
+
+func newAccountsService(client *Client) *AccountsService {
+	return &AccountsService{client}
+}
+
+func (service *AccountsService) Get(accountID int) (*Account, *http.Response, error) {
+	u := fmt.Sprintf("accounts/%d", accountID)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var account Account
+	resp, err := service.client.Do(req, &account)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &account, resp, nil
+}

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -133,16 +133,21 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 	for currentPage := 1; currentPage <= max; currentPage++ {
 		currentReqs := paginate(a.requests, currentPage, N, perPage)
 
-		a.aggregatedResponse = make(map[string]interface{})
+		aggregatedResponse := make(map[string]interface{})
 
 		req, err := a.service.client.NewRequest("POST", aggregatorURL, currentReqs)
 		if err != nil {
 			return nil, err
 		}
 
-		_, err = a.service.client.Do(req, &a.aggregatedResponse)
+		_, err = a.service.client.Do(req, &aggregatedResponse)
 		if err != nil {
 			return nil, err
+		}
+
+		// Appending the response body into the current aggregation for getters.
+		for url, response := range aggregatedResponse {
+			a.aggregatedResponse[url] = response
 		}
 	}
 

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -8,126 +8,191 @@ import (
 
 const aggregatorURL = "https://www.pivotaltracker.com/services/v5/aggregator"
 
+// AggregatorService is used to wrap the client.
 type AggregatorService struct {
-	client             *Client
-	requests           []string
-	aggregatedResponse map[string]interface{} // Storing the response temporarily.
+	client *Client
+}
+
+// Aggregation object stores the state of the aggregation.
+type Aggregation struct {
+	// Requests are the GET requests that are used by the aggregator.
+	requests []string
+
+	// Storing the response json along with the urls.
+	aggregatedResponse map[string]interface{}
+
+	// Map for quickly accessing the stories using their IDs
+	aggregatedData map[int]*AggregatedStory
+}
+
+// AggregatedStory contains the story, comment and review information.
+type AggregatedStory struct {
+	Story    *Story
+	Comments *[]Comment
+	Reviews  *[]Review
 }
 
 func newAggregatorService(client *Client) *AggregatorService {
-	return &AggregatorService{client, []string{}, nil}
+	return &AggregatorService{client}
 }
 
-// For making sure the request is in empty state
-func (service *AggregatorService) InitRequest() {
-	service.client.Aggregator.requests = []string{}
-	service.client.Aggregator.aggregatedResponse = make(map[string]interface{})
+func (a *Aggregation) maybeCreateAggregatedStory(StoryID int) *AggregatedStory {
+	story, ok := a.aggregatedData[StoryID]
+	if !ok {
+		a.aggregatedData[StoryID] = &AggregatedStory{}
+		return a.aggregatedData[StoryID]
+	}
+	return story
 }
 
-func (service *AggregatorService) QueueStoryCommentsByID(projectID, storyID int) {
+// Fills the urls for the aggregator and sends the request to PT.
+func (service *AggregatorService) fillAggregationData(ProjectID int, StoryIDs []int) (*Aggregation, error) {
+	aggregation := &Aggregation{
+		aggregatedResponse: make(map[string]interface{}),
+		aggregatedData:     make(map[int]*AggregatedStory),
+	}
+	for _, ID := range StoryIDs {
+		aggregation.queueStoryByID(ProjectID, ID)
+		aggregation.queueStoryCommentsByID(ProjectID, ID)
+		aggregation.queueReviewsByID(ProjectID, ID)
+	}
+	err := service.sendAggregationRequest(aggregation)
+	if err != nil {
+		return nil, err
+	}
+	return aggregation, nil
+}
+
+// Converts the JSON response from PT into the related structs(Story, Comment, Review).
+func (service *AggregatorService) processAggregationMaps(aggregation *Aggregation) (*Aggregation, error) {
+	// Creating the map with the story information.
+	for url, byteStory := range aggregation.aggregatedResponse {
+		byteData, _ := json.Marshal(byteStory)
+
+		if strings.Contains(url, "reviews") {
+			var reviews []Review
+			err := json.Unmarshal(byteData, &reviews)
+			if err != nil {
+				return nil, err
+			}
+			if len(reviews) == 0 {
+				continue
+			}
+			// Accessing the reviews using the story ID
+			storyData := aggregation.maybeCreateAggregatedStory(reviews[0].StoryID)
+			storyData.Reviews = &reviews
+			continue
+		}
+
+		if strings.Contains(url, "comments") {
+			var comments []Comment
+			err := json.Unmarshal(byteData, &comments)
+			if err != nil {
+				return nil, err
+			}
+			if len(comments) == 0 {
+				continue
+			}
+			// Accessing the reviews using the story ID
+			storyData := aggregation.maybeCreateAggregatedStory(comments[0].StoryID)
+			storyData.Comments = &comments
+			continue
+		}
+
+		// Handling get story requests if it isn't comments/reviews.
+		var story Story
+		err := json.Unmarshal(byteData, &story)
+		if err != nil {
+			return nil, err
+		}
+		if story.ID == 0 {
+			continue
+		}
+		// Accessing the story with the story ID
+		storyData := aggregation.maybeCreateAggregatedStory(story.ID)
+		storyData.Story = &story
+
+	}
+
+	return aggregation, nil
+}
+
+// BuildStoriesCommentsAndReviewsFor returns the reviews, comments and the story information
+// for the given project and story IDs.
+func (service *AggregatorService) BuildStoriesCommentsAndReviewsFor(ProjectID int, StoryIDs []int) (*Aggregation, error) {
+	if len(StoryIDs) > 5 {
+		// Aggregator doesn't seem to be returning more than 15 requests in total.
+		return nil, fmt.Errorf("There can be a maximum number of 5 Story IDs.")
+	}
+
+	aggregation, err := service.fillAggregationData(ProjectID, StoryIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	aggregation, err = service.processAggregationMaps(aggregation)
+	if err != nil {
+		return nil, err
+	}
+
+	return aggregation, nil
+}
+
+// Adds the url for the comments to the aggregation data.
+func (a *Aggregation) queueStoryCommentsByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/comments", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) QueueStoryByID(projectID, storyID int) {
+// Adds the url for the story to the aggregation data.
+func (a *Aggregation) queueStoryByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) QueueReviewsByID(projectID, storyID int) {
+// Adds the url for the reviews to the aggregation data.
+func (a *Aggregation) queueReviewsByID(projectID, storyID int) {
 	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/reviews?fields=id,story_id,review_type,review_type_id,reviewer_id,status,created_at,updated_at,kind", projectID, storyID)
-	service.requests = append(service.requests, u)
+	a.requests = append(a.requests, u)
 }
 
-func (service *AggregatorService) FinishRequest() error {
-	req, err := service.client.NewRequest("POST", aggregatorURL, service.requests)
+// Sends the request for the aggregation.
+func (service *AggregatorService) sendAggregationRequest(a *Aggregation) error {
+	req, err := service.client.NewRequest("POST", aggregatorURL, a.requests)
 	if err != nil {
 		return err
 	}
 
-	_, err = service.client.Do(req, &service.aggregatedResponse)
+	_, err = service.client.Do(req, &a.aggregatedResponse)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (service *AggregatorService) GetStoryReviewsFromRequest() (map[int][]Review, error) {
-	// For storing the comments using story IDs directly
-	reviewsMap := make(map[int][]Review)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not comments
-		if !strings.Contains(url, "reviews") {
-			continue
-		}
-		byteData, _ := json.Marshal(byteStory)
-
-		var reviews []Review
-		err := json.Unmarshal(byteData, &reviews)
-		if err != nil {
-			return nil, err
-		}
-		if len(reviews) == 0 {
-			break
-		}
-
-		// Updating the commentsMap using the StoryID
-		reviewsMap[reviews[0].StoryID] = reviews
+// Returns the story using StoryID from the aggregation.
+func (a *Aggregation) GetStory(storyID int) (*Story, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return reviewsMap, nil
-
+	return story.Story, nil
 }
 
-func (service *AggregatorService) GetStoryCommentsFromRequest() (map[int][]Comment, error) {
-	// For storing the comments using story IDs directly
-	commentsMap := make(map[int][]Comment)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not comments
-		if !strings.Contains(url, "comments") {
-			continue
-		}
-		byteData, _ := json.Marshal(byteStory)
-
-		var comments []Comment
-		err := json.Unmarshal(byteData, &comments)
-		if err != nil {
-			return nil, err
-		}
-		if len(comments) == 0 {
-			break
-		}
-
-		// Updating the commentsMap using the StoryID
-		commentsMap[comments[0].StoryID] = comments
+// Returns the comments using story id from the aggregation.
+func (a *Aggregation) GetComments(storyID int) ([]Comment, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return commentsMap, nil
-
+	return *story.Comments, nil
 }
 
-func (service *AggregatorService) GetStoriesFromRequest() (map[int]Story, error) {
-	// For storing the stories using IDs directly
-	storyIDMap := make(map[int]Story)
-
-	for url, byteStory := range service.aggregatedResponse {
-		// Skip the requests that are not labels.
-		if !strings.Contains(url, "stories") {
-			continue
-		}
-		byteData, err := json.Marshal(byteStory)
-		if err != nil {
-			return nil, err
-		}
-
-		var story Story
-		err = json.Unmarshal(byteData, &story)
-		if err != nil {
-			return nil, err
-		}
-
-		storyIDMap[story.ID] = story
+// Returns the reviews using the story id from the aggregation.
+func (a *Aggregation) GetReviews(storyID int) ([]Review, error) {
+	story, ok := a.aggregatedData[storyID]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
 	}
-	return storyIDMap, nil
-
+	return *story.Reviews, nil
 }

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -1,0 +1,133 @@
+package pivotal
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const aggregatorURL = "https://www.pivotaltracker.com/services/v5/aggregator"
+
+type AggregatorService struct {
+	client             *Client
+	requests           []string
+	aggregatedResponse map[string]interface{} // Storing the response temporarily.
+}
+
+func newAggregatorService(client *Client) *AggregatorService {
+	return &AggregatorService{client, []string{}, nil}
+}
+
+// For making sure the request is in empty state
+func (service *AggregatorService) InitRequest() {
+	service.client.Aggregator.requests = []string{}
+	service.client.Aggregator.aggregatedResponse = make(map[string]interface{})
+}
+
+func (service *AggregatorService) QueueStoryCommentsByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/comments", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) QueueStoryByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) QueueReviewsByID(projectID, storyID int) {
+	u := fmt.Sprintf("/services/v5/projects/%d/stories/%d/reviews?fields=id,story_id,review_type,review_type_id,reviewer_id,status,created_at,updated_at,kind", projectID, storyID)
+	service.requests = append(service.requests, u)
+}
+
+func (service *AggregatorService) FinishRequest() error {
+	req, err := service.client.NewRequest("POST", aggregatorURL, service.requests)
+	if err != nil {
+		return err
+	}
+
+	_, err = service.client.Do(req, &service.aggregatedResponse)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (service *AggregatorService) GetStoryReviewsFromRequest() (map[int][]Review, error) {
+	// For storing the comments using story IDs directly
+	reviewsMap := make(map[int][]Review)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not comments
+		if !strings.Contains(url, "reviews") {
+			continue
+		}
+		byteData, _ := json.Marshal(byteStory)
+
+		var reviews []Review
+		err := json.Unmarshal(byteData, &reviews)
+		if err != nil {
+			return nil, err
+		}
+		if len(reviews) == 0 {
+			break
+		}
+
+		// Updating the commentsMap using the StoryID
+		reviewsMap[reviews[0].StoryID] = reviews
+	}
+	return reviewsMap, nil
+
+}
+
+func (service *AggregatorService) GetStoryCommentsFromRequest() (map[int][]Comment, error) {
+	// For storing the comments using story IDs directly
+	commentsMap := make(map[int][]Comment)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not comments
+		if !strings.Contains(url, "comments") {
+			continue
+		}
+		byteData, _ := json.Marshal(byteStory)
+
+		var comments []Comment
+		err := json.Unmarshal(byteData, &comments)
+		if err != nil {
+			return nil, err
+		}
+		if len(comments) == 0 {
+			break
+		}
+
+		// Updating the commentsMap using the StoryID
+		commentsMap[comments[0].StoryID] = comments
+	}
+	return commentsMap, nil
+
+}
+
+func (service *AggregatorService) GetStoriesFromRequest() (map[int]Story, error) {
+	// For storing the stories using IDs directly
+	storyIDMap := make(map[int]Story)
+
+	for url, byteStory := range service.aggregatedResponse {
+		// Skip the requests that are not labels.
+		if !strings.Contains(url, "stories") {
+			continue
+		}
+		byteData, err := json.Marshal(byteStory)
+		if err != nil {
+			return nil, err
+		}
+
+		var story Story
+		err = json.Unmarshal(byteData, &story)
+		if err != nil {
+			return nil, err
+		}
+
+		storyIDMap[story.ID] = story
+	}
+	return storyIDMap, nil
+
+}

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -54,6 +54,11 @@ func (a *Aggregation) Story(projectID, storyID int) *Aggregation {
 	return a
 }
 
+func (a *Aggregation) StoryUsingStoryID(storyID int) *Aggregation {
+	a.requests = append(a.requests, BuildStoryURLOnlyUsingStoryID(storyID))
+	return a
+}
+
 // Stories adds the urls for the slice of story IDs.
 func (a *Aggregation) Stories(projectID int, storyIDs []int) *Aggregation {
 	for _, storyID := range storyIDs {
@@ -87,6 +92,10 @@ func (a *Aggregation) ReviewsOfStories(projectID int, storyIDs []int) *Aggregati
 		a.ReviewsOfStory(projectID, storyID)
 	}
 	return a
+}
+
+func BuildStoryURLOnlyUsingStoryID(storyID int) string {
+	return fmt.Sprintf("/services/v5/stories/%d", storyID)
 }
 
 func BuildStoryURL(projectID, storyID int) string {
@@ -138,6 +147,24 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 	}
 
 	return a, nil
+}
+
+// Returns the story using StoryID from the aggregation.
+func (a *Aggregation) GetStoryOnlyUsingStoryID(storyID int) (*Story, error) {
+	u := BuildStoryURLOnlyUsingStoryID(storyID)
+	response, ok := a.aggregatedResponse[u]
+	if !ok {
+		return nil, fmt.Errorf("Story %d doesn't exist.", storyID)
+	}
+	byteData, _ := json.Marshal(response)
+
+	// Handling get story requests if it isn't comments/reviews.
+	var story Story
+	err := json.Unmarshal(byteData, &story)
+	if err != nil {
+		return nil, err
+	}
+	return &story, nil
 }
 
 // Returns the story using StoryID from the aggregation.

--- a/v5/pivotal/aggregator.go
+++ b/v5/pivotal/aggregator.go
@@ -39,8 +39,7 @@ type Aggregation struct {
 func (a *AggregatorService) GetBuilder() *Aggregation {
 	aggregation := Aggregation{
 		aggregatedResponse: make(map[string]interface{}),
-		// aggregatedData:     make(map[int]*AggregatedStory),
-		service: a,
+		service:            a,
 	}
 	return &aggregation
 }
@@ -136,8 +135,6 @@ func (a *Aggregation) Send() (*Aggregation, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		// a.processAggregationMaps()
 	}
 
 	return a, nil

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -57,6 +57,9 @@ type Client struct {
 
 	// Epic Service
 	Epic *EpicService
+
+	// Aggregator Service
+	Aggregator *AggregatorService
 }
 
 // NewClient takes a Pivotal Tracker API Token (created from the project settings) and
@@ -76,6 +79,7 @@ func NewClient(apiToken string) *Client {
 	client.Iterations = newIterationService(client)
 	client.Activity = newActivitiesService(client)
 	client.Epic = newEpicService(client)
+	client.Aggregator = newAggregatorService(client)
 	return client
 }
 

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -37,6 +37,9 @@ type Client struct {
 	// User-Agent header to use when connecting to the Pivotal Tracker API.
 	userAgent string
 
+	// Accounts service
+	Accounts *AccountsService
+
 	// Me service
 	Me *MeService
 
@@ -72,6 +75,7 @@ func NewClient(apiToken string) *Client {
 		baseURL:   baseURL,
 		userAgent: defaultUserAgent,
 	}
+	client.Accounts = newAccountsService(client)
 	client.Me = newMeService(client)
 	client.Projects = newProjectService(client)
 	client.Stories = newStoryService(client)

--- a/v5/pivotal/client.go
+++ b/v5/pivotal/client.go
@@ -94,6 +94,11 @@ func (c *Client) SetBaseURL(baseURL string) error {
 	return nil
 }
 
+// SetHTTPClient overrides the default HTTP Client, http.DefaultClient.
+func (c *Client) SetHTTPClient(client *http.Client) {
+	c.client = client
+}
+
 // SetUserAgent overrides the defaultUserAgent in the default Client implementation.
 func (c *Client) SetUserAgent(agent string) {
 	c.userAgent = agent

--- a/v5/pivotal/me.go
+++ b/v5/pivotal/me.go
@@ -9,21 +9,40 @@ import (
 	"time"
 )
 
+// MeProject represents the fields of the projects returned by the MeService.
+// These are the only fields returned by the MeService unlike
+// the Project service.
+type MeProject struct {
+	Kind         string     `json:"kind"`
+	ID           int        `json:"id"`
+	ProjectID    int        `json:"project_id"`
+	ProjectName  string     `json:"project_name"`
+	ProjectColor string     `json:"project_color"`
+	Favorite     bool       `json:"favorite"`
+	Role         string     `json:"owner"`
+	LastViewedAt *time.Time `json:"last_viewed_at"`
+}
+
 // Me is the primary data object for the MeService.
 type Me struct {
-	ID                         int        `json:"id"`
-	Name                       string     `json:"name"`
-	Initials                   string     `json:"initials"`
-	Username                   string     `json:"username"`
-	TimeZone                   *TimeZone  `json:"time_zone"`
-	APIToken                   string     `json:"api_token"`
-	HasGoogleIdentity          bool       `json:"has_google_identity"`
-	ProjectIDs                 *[]int     `json:"project_ids"`
-	WorkspaceIDs               *[]int     `json:"workspace_ids"`
-	Email                      string     `json:"email"`
-	ReceivedInAppNotifications bool       `json:"receives_in_app_notifications"`
-	CreatedAt                  *time.Time `json:"created_at"`
-	UpdatedAt                  *time.Time `json:"updated_at"`
+	ID                int       `json:"id"`
+	Name              string    `json:"name"`
+	Initials          string    `json:"initials"`
+	Username          string    `json:"username"`
+	TimeZone          *TimeZone `json:"time_zone"`
+	APIToken          string    `json:"api_token"`
+	HasGoogleIdentity bool      `json:"has_google_identity"`
+
+	// TODO: The ProjectIDs field needs to be requested explicitly using
+	// the fields query parameter. It is never populated unlike Projects,
+	// which is populated by default.
+	ProjectIDs                 *[]int       `json:"project_ids"`
+	Projects                   *[]MeProject `json:"projects"`
+	WorkspaceIDs               *[]int       `json:"workspace_ids"`
+	Email                      string       `json:"email"`
+	ReceivedInAppNotifications bool         `json:"receives_in_app_notifications"`
+	CreatedAt                  *time.Time   `json:"created_at"`
+	UpdatedAt                  *time.Time   `json:"updated_at"`
 }
 
 // MeService wraps the client context for interacting with the Me logic.

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -87,6 +87,7 @@ type StoryRequest struct {
 	RequestedByID int       `json:"requested_by_id,omitempty"`
 	OwnerIDs      *[]int    `json:"owner_ids,omitempty"`
 	LabelIDs      *[]int    `json:"label_ids,omitempty"`
+	BeforeID      *int      `json:"before_id,omitempty"`
 	Labels        *[]*Label `json:"labels,omitempty"`
 	TaskIDs       *[]int    `json:"task_ids,omitempty"`
 	Tasks         *[]int    `json:"tasks,omitempty"`

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -157,14 +157,26 @@ type BlockerRequest struct {
 
 // Review is a review on a PT story
 type Review struct {
-	ID           int        `json:"id,omitempty"`
-	StoryID      int        `json:"story_id,omitempty"`
-	ReviewTypeID int        `json:"review_type_id,omitempty"`
-	ReviewerID   int        `json:"reviewer_id,omitempty"`
-	Status       string     `json:"status,omitempty"`
-	CreatedAt    *time.Time `json:"created_at,omitempty"`
-	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
-	Kind         string     `json:"kind,omitempty"`
+	ID           int         `json:"id,omitempty"`
+	StoryID      int         `json:"story_id,omitempty"`
+	ReviewType   *ReviewType `json:"review_type,omitempty"`
+	ReviewTypeID int         `json:"review_type_id,omitempty"`
+	ReviewerID   int         `json:"reviewer_id,omitempty"`
+	Status       string      `json:"status,omitempty"`
+	CreatedAt    *time.Time  `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time  `json:"updated_at,omitempty"`
+	Kind         string      `json:"kind,omitempty"`
+}
+
+// ReviewType is a review_type resource.
+type ReviewType struct {
+	ID        int        `json:"id,omitempty"`
+	ProjectID int        `json:"project_id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Hidden    bool       `json:"hidden,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	Kind      string     `json:"kind,omitempty"`
 }
 
 // StoryService wraps the client context and allows for interaction
@@ -479,7 +491,11 @@ func (service *StoryService) ListReviews(
 	storyID int,
 ) ([]*Review, *http.Response, error) {
 
-	u := fmt.Sprintf("projects/%v/stories/%v/reviews", projectID, storyID)
+	u := fmt.Sprintf(
+		"projects/%v/stories/%v/reviews?fields=id,story_id,review_type,review_type_id,reviewer_id,status,created_at,updated_at,kind",
+		projectID,
+		storyID,
+	)
 	req, err := service.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -260,9 +260,26 @@ func (service *StoryService) Create(projectID int, story *StoryRequest) (*Story,
 	return &newStory, resp, nil
 }
 
-// Get will obtain the details about a single Story by ID.
+// Get will obtain the details about a single Story by project and story ID.
 func (service *StoryService) Get(projectID, storyID int) (*Story, *http.Response, error) {
 	u := fmt.Sprintf("projects/%v/stories/%v", projectID, storyID)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var story Story
+	resp, err := service.client.Do(req, &story)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return &story, resp, err
+}
+
+// GetByID will obtain the details about a single Story by the story ID only.
+func (service *StoryService) GetByID(storyID int) (*Story, *http.Response, error) {
+	u := fmt.Sprintf("stories/%d", storyID)
 	req, err := service.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -218,10 +218,9 @@ func newStoriesRequestFunc(client *Client, projectID int, filter string, fields 
 		u := fmt.Sprintf("projects/%v/stories", projectID)
 		if filter != "" {
 			u += "?filter=" + url.QueryEscape(filter)
-			if len(fields) == 0 {
-				fields = DefaultFields
+			if len(fields) != 0 {
+				u += "&fields=" + url.QueryEscape(fieldsToQuery(fields))
 			}
-			u += "&fields=" + url.QueryEscape(fieldsToQuery(fields))
 		}
 		req, _ := client.NewRequest("GET", u, nil)
 		return req

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -155,6 +155,18 @@ type BlockerRequest struct {
 	Resolved    *bool  `json:"resolved,omitempty"`
 }
 
+// Review is a review on a PT story
+type Review struct {
+	ID           int        `json:"id,omitempty"`
+	StoryID      int        `json:"story_id,omitempty"`
+	ReviewTypeID int        `json:"review_type_id,omitempty"`
+	ReviewerID   int        `json:"reviewer_id,omitempty"`
+	Status       string     `json:"status,omitempty"`
+	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
+	Kind         string     `json:"kind,omitempty"`
+}
+
 // StoryService wraps the client context and allows for interaction
 // with the Pivotal Tracker Story API.
 type StoryService struct {
@@ -459,4 +471,25 @@ func (service *StoryService) UpdateBlocker(projectID, storyID, blockerID int, bl
 	}
 
 	return &blockerResp, resp, nil
+}
+
+// ListReviews returns the list of Reviews in a Story.
+func (service *StoryService) ListReviews(
+	projectID int,
+	storyID int,
+) ([]*Review, *http.Response, error) {
+
+	u := fmt.Sprintf("projects/%v/stories/%v/reviews", projectID, storyID)
+	req, err := service.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var reviews []*Review
+	resp, err := service.client.Do(req, &reviews)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return reviews, resp, nil
 }

--- a/v5/pivotal/stories.go
+++ b/v5/pivotal/stories.go
@@ -79,18 +79,19 @@ type Story struct {
 
 // StoryRequest is a simplified Story object for use in Create/Update/Delete operations.
 type StoryRequest struct {
-	Name        string    `json:"name,omitempty"`
-	Description string    `json:"description,omitempty"`
-	Type        string    `json:"story_type,omitempty"`
-	State       string    `json:"current_state,omitempty"`
-	Estimate    *float64  `json:"estimate,omitempty"`
-	OwnerIDs    *[]int    `json:"owner_ids,omitempty"`
-	LabelIDs    *[]int    `json:"label_ids,omitempty"`
-	Labels      *[]*Label `json:"labels,omitempty"`
-	TaskIDs     *[]int    `json:"task_ids,omitempty"`
-	Tasks       *[]int    `json:"tasks,omitempty"`
-	FollowerIDs *[]int    `json:"follower_ids,omitempty"`
-	CommentIDs  *[]int    `json:"comment_ids,omitempty"`
+	Name          string    `json:"name,omitempty"`
+	Description   string    `json:"description,omitempty"`
+	Type          string    `json:"story_type,omitempty"`
+	State         string    `json:"current_state,omitempty"`
+	Estimate      *float64  `json:"estimate,omitempty"`
+	RequestedByID int       `json:"requested_by_id,omitempty"`
+	OwnerIDs      *[]int    `json:"owner_ids,omitempty"`
+	LabelIDs      *[]int    `json:"label_ids,omitempty"`
+	Labels        *[]*Label `json:"labels,omitempty"`
+	TaskIDs       *[]int    `json:"task_ids,omitempty"`
+	Tasks         *[]int    `json:"tasks,omitempty"`
+	FollowerIDs   *[]int    `json:"follower_ids,omitempty"`
+	CommentIDs    *[]int    `json:"comment_ids,omitempty"`
 }
 
 // Label is a child object of a Story. This may need to be broken out into a LabelService


### PR DESCRIPTION
Hi,

This package currently doesn't support the aggregator endpoint, which is super useful at decreasing the amount of requests that could be made to PivotalTracker. 

https://www.pivotaltracker.com/help/api/#Using_the_GET_Request_Aggregator

This PR adds a new service to the package for using the aggregator. It currently only supports getting the **stories, comments of stories** and **reviews of stories**. However, if the pattern is approved, I believe the API could be extended to support other parts of PivotalTracker.

Note: It uses some parts from the fork https://github.com/oschwald/go-pivotaltracker.

A sample use would be similar to below,
```
ptClient := pivotal.NewClient("TOKEN")
storiesToGet := []int{
	1,
	2,
	3,
	4,
}
projectID := 123
aggregation := ptClient.Aggregator.GetBuilder().Stories(projectID, storiesToGet).Story(projectID, 5)
aggregation.CommentsOfStories(projectID, storiesToGet).ReviewsOfStories(projectID, storiesToGet)
aggregation, err := aggregation.Send()
_ = err

story, _ := aggregation.GetStory(projectID, 1)
comments, _ := aggregation.GetComments(projectID, 2)
reviews, _ := aggregation.GetReviews(projectID, 2)
_ = story

```

